### PR TITLE
Remove extra call to coffeecatch_handler_cleanup

### DIFF
--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -1397,7 +1397,6 @@ void coffeecatch_cleanup() {
   t->reenter--;
   if (t->reenter == 0) {
     t->ctx_is_set = 0;
-    coffeecatch_handler_cleanup();
   }
   coffeecatch_handler_cleanup();
 }

--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -1397,8 +1397,8 @@ void coffeecatch_cleanup() {
   t->reenter--;
   if (t->reenter == 0) {
     t->ctx_is_set = 0;
+    coffeecatch_handler_cleanup();
   }
-  coffeecatch_handler_cleanup();
 }
 
 sigjmp_buf* coffeecatch_get_ctx() {


### PR DESCRIPTION
It doesn't appear this was intended to be called twice. It results in `native_code_g.initialized` being decremented twice so the next time a JNI call is made, `coffeecatch_handler_setup_global` doesn't reinitialize (because the value in `initialized` is now negative instead of zero).
