### PR TITLE
Feature/more debug

### DIFF
--- a/coffeecatch.h
+++ b/coffeecatch.h
@@ -220,6 +220,19 @@ extern void coffeecatch_cleanup(void);
 #define COFFEE_END() coffeecatch_cleanup()
 /** End of internal functions & definitions. **/
 
+
+
+#if ( defined(NDK_DEBUG) && ( NDK_DEBUG == 2 ) )
+//external printers must be provided by application to log coffee messages
+void coffeecatch_print(const char * s);
+void coffeecatch_printf(const char * fmt, ...);
+#endif
+
+// this is debug dump of coffee context state
+void coffeecatch_dump(void);
+
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
with NDK_DEBUG == 2 provide printing debug messages by application-specifie printers coffeecatch_print[f]. This hepls when aplication override serial for own purposes.

Debug mode infer more trace messages.

provided ERROR( ) - for printing error messages, that seen even without NDK_DEBUG .

provided ASSERT( cond ) - prints with cspecified printers when asserted. helpful
   when application is captured stdio, so asserts not shows in console.
