### PR TITLE
Support x86_64 Android ucontext layout

### DIFF
--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -209,6 +209,12 @@ typedef struct ucontext {
 } ucontext_t;
 #endif
 
+#elif defined(__x86_64__)
+
+/* Modern bionic provides ucontext_t / mcontext_t for x86_64 natively (as it does
+   for __aarch64__ above), so no hand-rolled fallback typedef is needed. The PC is
+   read below via uc_mcontext.gregs[REG_RIP]. */
+
 #else
 #error "Architecture is not supported (unknown ucontext layout)"
 #endif


### PR DESCRIPTION
Adds an `__x86_64__` case to the Android ucontext-layout selection so coffeecatch builds for the x86_64 ABI. The legacy fallback block (compiled when `__BIONIC_HAVE_UCONTEXT_T` is undefined, i.e. on modern NDK) chains `__arm__`, `__aarch64__`, `__i386__`, `__mips__` and then hard-errors with "Architecture is not supported (unknown ucontext layout)"; x86_64 fell through to that `#error` and broke the Android x86_64 build. `__aarch64__` is already handled by an empty branch because modern bionic supplies `ucontext_t`/`mcontext_t` natively, and it does the same for x86_64, so the fix is an empty `#elif defined(__x86_64__)` branch before the `#else`. No fallback typedef is needed; the program counter is already read via `uc_mcontext.gregs[REG_RIP]`.

With this change an Android ndk-build (NDK r26d, API 24) links coffeecatch for x86_64 alongside the already-working arm64-v8a and armeabi-v7a.