### PR TITLE
Add a test suite and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
-# Build and test CoffeeCatch across compilers, architectures, macOS, and UBSan.
+# Build and test CoffeeCatch across compilers, architectures, and UBSan.
 # The library ships as a hand-written Makefile, so CI drives it directly: that
 # is exactly what rotted unnoticed before (transposed calloc args and a stale
 # link order broke `make` on modern toolchains, with no CI to catch it).
+# macOS is not covered: the ucontext register access and a few signals in
+# coffeecatch.c are Linux/Android-only and do not compile on Darwin. The arm64
+# Linux leg is the closest proxy for the Android arm64 target.
 name: CI
 
 on:
@@ -72,15 +75,3 @@ jobs:
           make check \
             CFLAGS="-O1 -g -fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" \
             LDFLAGS="-fsanitize=undefined"
-
-  macos:
-    name: build+test (macOS arm64, clang)
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v6
-
-      # The Makefile is portable (it switches to a .dylib link on Darwin), and
-      # the tests link the static archive, so macOS runs the same
-      # `make all check` on a second libc/kernel and on Apple clang.
-      - name: Build and test
-        run: make all check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+# Build and test CoffeeCatch across compilers, architectures, macOS, and UBSan.
+# The library ships as a hand-written Makefile, so CI drives it directly: that
+# is exactly what rotted unnoticed before (transposed calloc args and a stale
+# link order broke `make` on modern toolchains, with no CI to catch it).
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+# Least privilege: the workflow only needs to read the repo.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same branch or PR.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build+test (${{ matrix.arch }}, ${{ matrix.cc }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x86-64, runner: ubuntu-24.04,     cc: gcc }
+          - { arch: x86-64, runner: ubuntu-24.04,     cc: clang }
+          - { arch: arm64,  runner: ubuntu-24.04-arm, cc: gcc }
+          - { arch: arm64,  runner: ubuntu-24.04-arm, cc: clang }
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install toolchain
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential clang
+
+      # `make all` builds the static lib, shared lib, tests, and sample under
+      # the chosen compiler; `make check` runs the test suite.
+      - name: Build and test
+        run: make all check CC=${{ matrix.cc }}
+
+  ubsan:
+    name: sanitizer (ubsan, gcc)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install toolchain
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential
+
+      # UBSan only, on purpose: coffeecatch installs its own SIGSEGV/SIGABRT/...
+      # handlers and a per-thread alternate signal stack, which ASan's own
+      # signal handling and altstack cannot coexist with (every intentional
+      # crash then dies uncaught). UBSan installs no signal handlers, so it
+      # runs the suite as-is and still checks the C for alignment, integer
+      # overflow, shift, and other UB. Flags ride in via CFLAGS/LDFLAGS, which
+      # the Makefile appends its mandatory flags onto; every finding aborts.
+      - name: Build and run under UBSan
+        env:
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: |
+          set -euo pipefail
+          make check \
+            CFLAGS="-O1 -g -fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" \
+            LDFLAGS="-fsanitize=undefined"
+
+  macos:
+    name: build+test (macOS arm64, clang)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      # The Makefile is portable (it switches to a .dylib link on Darwin), and
+      # the tests link the static archive, so macOS runs the same
+      # `make all check` on a second libc/kernel and on Apple clang.
+      - name: Build and test
+        run: make all check

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.o
+*.a
+*.so
+*.so.*
+*.dylib
+/tests
+/sample
+/coffeecatch.tgz

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,77 @@
 ###############################################################################
 #
-# "FastLZ" compression library
+# CoffeeCatch — tiny native POSIX signal catcher
 #
 ###############################################################################
 
-CFILES = coffeecatch.c
+# --- Toolchain (overridable) -------------------------------------------------
+# cc/ar are the POSIX defaults; CI overrides CC with clang or "gcc -m32".
+CC      ?= cc
+AR      ?= ar
+RM      ?= rm -f
 
-all: gcc test
+# --- Flags -------------------------------------------------------------------
+# CFLAGS holds the user-overridable optimization/debug flags. Everything
+# mandatory (PIC, reentrancy, strict warnings) is appended with `override` so
+# it survives a command-line CFLAGS=... — e.g. CI injecting sanitizer flags.
+CFLAGS  ?= -O3 -g
+
+override CPPFLAGS += -D_REENTRANT -D_GNU_SOURCE
+override CFLAGS   += -fPIC -pthread \
+                    -W -Wall -Wextra -Werror -Wno-unused-function
+
+# --- Platform shared-library wiring ------------------------------------------
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+  SHLIB   := libcoffeecatch.dylib
+  SOFLAGS := -dynamiclib -install_name @rpath/$(SHLIB)
+  SOLIBS  :=
+  LDLIBS  :=
+else
+  SHLIB   := libcoffeecatch.so
+  SOFLAGS := -shared -Wl,-soname=$(SHLIB) -Wl,--no-undefined -rdynamic
+  SOLIBS  := -ldl
+  LDLIBS  := -ldl
+endif
+
+STATICLIB := libcoffeecatch.a
+
+# --- Sources -----------------------------------------------------------------
+# coffeejni.c is intentionally excluded: it needs <jni.h> (an NDK/JDK header)
+# and is meant to be compiled into the embedder, not this standalone build.
+LIBSRC := coffeecatch.c
+LIBOBJ := $(LIBSRC:.c=.o)
+BINS   := tests sample
+
+# --- Targets -----------------------------------------------------------------
+.PHONY: all check test clean dist
+.DEFAULT_GOAL := all
+
+all: $(STATICLIB) $(SHLIB) $(BINS)
+
+%.o: %.c coffeecatch.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+$(STATICLIB): $(LIBOBJ)
+	$(AR) rcs $@ $^
+
+$(SHLIB): $(LIBOBJ)
+	$(CC) $(CFLAGS) $(SOFLAGS) $(LIBOBJ) -o $@ $(LDFLAGS) $(SOLIBS) $(LDLIBS)
+
+# tests/sample link the static archive: no LD_LIBRARY_PATH, identical run on
+# Linux and macOS.
+tests: tests.o $(STATICLIB)
+	$(CC) $(CFLAGS) $< $(STATICLIB) -o $@ $(LDFLAGS) $(LDLIBS)
+sample: sample.o $(STATICLIB)
+	$(CC) $(CFLAGS) $< $(STATICLIB) -o $@ $(LDFLAGS) $(LDLIBS)
+
+check test: tests
+	./tests
+
+dist:
+	$(RM) coffeecatch.tgz
+	tar cvfz coffeecatch.tgz $(LIBSRC) coffeecatch.h coffeejni.c coffeejni.h \
+		sample.c tests.c Makefile LICENSE README.md
 
 clean:
-	rm -f *.o *.obj *.so* *.dll *.exe *.pdb *.exp *.lib sample
-
-tar:
-	rm -f coffeecatch.tgz
-	tar cvfz coffeecatch.tgz coffeecatch.txt coffeecatch.c coffeecatch.h Makefile LICENSE README.md
-
-gcc:
-	gcc -c -fPIC -O3 -g3 -pthread \
-		-W -Wall -Wextra -Werror -Wno-unused-function \
-		-D_REENTRANT -D_GNU_SOURCE \
-		$(CFILES)
-	gcc -shared -fPIC -O3 -Wl,-O1 -Wl,--no-undefined \
-		-rdynamic -shared -Wl,-soname=libcoffeecatch.so \
-		coffeecatch.o -o libcoffeecatch.so \
-		-ldl -lpthread
-
-test:
-	gcc -c -fPIC -O3 -g3 \
-		-W -Wall -Wextra -Werror -Wno-unused-function \
-		-D_REENTRANT \
-		sample.c -o sample.o
-	gcc -fPIC -O3 -Wl,-O1 \
-		sample.o -o sample \
-		-L. -lcoffeecatch
-
+	$(RM) *.o $(STATICLIB) $(SHLIB) libcoffeecatch.so.* $(BINS) coffeecatch.tgz

--- a/tests.c
+++ b/tests.c
@@ -1,0 +1,302 @@
+/* CoffeeCatch test suite.
+ *
+ * Copyright (c) 2013, Xavier Roche (http://www.httrack.com/)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the conditions in the LICENSE
+ * file are met.
+ *
+ * Each case runs in its own forked child: coffeecatch installs process-global
+ * signal handlers and keeps per-thread state, so isolation keeps one case's
+ * crash (or an uncaught signal) from corrupting the runner or the next case.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <stdint.h>
+#include <pthread.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "coffeecatch.h"
+
+/* COFFEE_TRY requires its enclosing function to be non-inlined. */
+#define NOINLINE __attribute__ ((noinline))
+
+/* Fail the current test with context. Only valid outside a TRY/CATCH block:
+ * a return must never cross COFFEE_TRY/CATCH/END or cleanup is skipped. */
+#define CHECK(cond)                                                     \
+  do {                                                                  \
+    if (!(cond)) {                                                      \
+      fprintf(stderr, "    check failed: %s (%s:%d)\n",                 \
+              #cond, __FILE__, __LINE__);                               \
+      return 1;                                                         \
+    }                                                                   \
+  } while (0)
+
+/* An address in the unmapped first page, so writing through it faults. Kept in
+ * a volatile so the compiler cannot fold it and reject the store at compile
+ * time (-Warray-bounds). Aligned to int so UBSan does not report the store as
+ * misalignment UB before the hardware fault the handler is meant to catch. */
+static volatile uintptr_t bad_addr = 0x100;
+#define CRASH() (*(volatile int *) bad_addr = 1)
+
+/* --- individual cases: return 0 on success, 1 on failure ----------------- */
+
+static NOINLINE int test_segv(void) {
+  volatile int caught = 0, sig = 0, have_msg = 0;
+  COFFEE_TRY() {
+    CRASH();
+  } COFFEE_CATCH() {
+    const char *const msg = coffeecatch_get_message();
+    caught = 1;
+    sig = coffeecatch_get_signal();
+    have_msg = msg != NULL && msg[0] != '\0';
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  CHECK(caught);
+  CHECK(sig == SIGSEGV);
+  CHECK(have_msg);
+  return 0;
+}
+
+/* raise() rather than a real division trap: integer div-by-zero is itself UB
+ * that UBSan reports before the signal, and it does not trap at all on some
+ * arches. This exercises the same SIGFPE catch path portably. */
+static NOINLINE int test_fpe(void) {
+  volatile int caught = 0, sig = 0;
+  COFFEE_TRY() {
+    raise(SIGFPE);
+  } COFFEE_CATCH() {
+    caught = 1;
+    sig = coffeecatch_get_signal();
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  CHECK(caught);
+  CHECK(sig == SIGFPE);
+  return 0;
+}
+
+static NOINLINE int test_abort(void) {
+  volatile int caught = 0, sig = 0;
+  COFFEE_TRY() {
+    coffeecatch_abort("deliberate", __FILE__, __LINE__);
+  } COFFEE_CATCH() {
+    caught = 1;
+    sig = coffeecatch_get_signal();
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  CHECK(caught);
+  CHECK(sig == SIGABRT);
+  return 0;
+}
+
+static NOINLINE int test_assert_fail(void) {
+  volatile int caught = 0, sig = 0;
+  COFFEE_TRY() {
+    coffeecatch_assert(1 == 2);
+  } COFFEE_CATCH() {
+    caught = 1;
+    sig = coffeecatch_get_signal();
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  CHECK(caught);
+  CHECK(sig == SIGABRT);
+  return 0;
+}
+
+static NOINLINE int test_assert_pass(void) {
+  volatile int caught = 0, reached = 0;
+  COFFEE_TRY() {
+    coffeecatch_assert(1 == 1);
+    reached = 1;
+  } COFFEE_CATCH() {
+    caught = 1;
+  } COFFEE_END();
+  CHECK(reached);
+  CHECK(!caught);
+  return 0;
+}
+
+static NOINLINE int test_no_crash(void) {
+  volatile int caught = 0, reached = 0;
+  COFFEE_TRY() {
+    reached = 1;
+  } COFFEE_CATCH() {
+    caught = 1;
+  } COFFEE_END();
+  CHECK(reached);
+  CHECK(!caught);
+  return 0;
+}
+
+/* A clean catch must leave the thread able to protect another block. */
+static NOINLINE int test_reentry(void) {
+  volatile int first = 0, second = 0;
+  COFFEE_TRY() {
+    CRASH();
+  } COFFEE_CATCH() {
+    first = 1;
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  COFFEE_TRY() {
+    CRASH();
+  } COFFEE_CATCH() {
+    second = 1;
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  CHECK(first);
+  CHECK(second);
+  return 0;
+}
+
+/* A crash inside a nested block unwinds to the outermost handler; the inner
+ * CATCH and the rest of the outer TRY body are skipped. */
+static NOINLINE int test_nested(void) {
+  volatile int outer_caught = 0, inner_caught = 0, outer_after = 0;
+  COFFEE_TRY() {
+    COFFEE_TRY() {
+      CRASH();
+    } COFFEE_CATCH() {
+      inner_caught = 1;
+    } COFFEE_END();
+    outer_after = 1;
+  } COFFEE_CATCH() {
+    outer_caught = 1;
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  CHECK(outer_caught);
+  CHECK(!inner_caught);
+  CHECK(!outer_after);
+  return 0;
+}
+
+static NOINLINE int test_cancel_alarm(void) {
+  volatile int caught = 0, rc = -1;
+  COFFEE_TRY() {
+    CRASH();
+  } COFFEE_CATCH() {
+    caught = 1;
+    rc = coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  CHECK(caught);
+  CHECK(rc == 0);
+  return 0;
+}
+
+static NOINLINE void *thread_body(void *arg) {
+  volatile int *const caught = (volatile int *) arg;
+  COFFEE_TRY() {
+    CRASH();
+  } COFFEE_CATCH() {
+    *caught = 1;
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  return NULL;
+}
+
+/* The handler is documented thread-safe: concurrent catches must all succeed. */
+static NOINLINE int test_threads(void) {
+  enum { N = 8 };
+  pthread_t th[N];
+  volatile int caught[N];
+  int i;
+  for (i = 0; i < N; i++) {
+    caught[i] = 0;
+  }
+  for (i = 0; i < N; i++) {
+    CHECK(pthread_create(&th[i], NULL, thread_body, (void *) &caught[i]) == 0);
+  }
+  for (i = 0; i < N; i++) {
+    CHECK(pthread_join(th[i], NULL) == 0);
+  }
+  for (i = 0; i < N; i++) {
+    CHECK(caught[i]);
+  }
+  return 0;
+}
+
+/* --- fork harness -------------------------------------------------------- */
+
+struct test {
+  const char *name;
+  int (*fn)(void);
+  const char *skip;   /* non-NULL: reason the case is not run */
+};
+
+static const struct test tests[] = {
+  { "segv (null deref)",            test_segv,        NULL },
+  { "fpe (raised)",                 test_fpe,         NULL },
+  { "abort()",                      test_abort,       NULL },
+  { "assert(false)",                test_assert_fail, NULL },
+  { "assert(true) passthrough",     test_assert_pass, NULL },
+  { "no-crash passthrough",         test_no_crash,    NULL },
+  { "reentry after catch",          test_reentry,     NULL },
+  { "nested throws to outermost",   test_nested,      NULL },
+  { "cancel_pending_alarm",         test_cancel_alarm, NULL },
+  /* Reliably kills the process with 2+ threads: the handler resets the signal
+   * disposition to SIG_DFL, which is process-wide, so one thread's catch
+   * disarms the others. Enable once the core handler is fixed. */
+  { "concurrent catches (threads)", test_threads,
+    "concurrent catch resets signal disposition process-wide" },
+};
+
+static int run_forked(const struct test *t) {
+  pid_t pid;
+  int status = 0;
+
+  if (t->skip != NULL) {
+    printf("  SKIP  %s (%s)\n", t->name, t->skip);
+    return 0;
+  }
+
+  fflush(stdout);
+  fflush(stderr);
+  pid = fork();
+  if (pid < 0) {
+    perror("fork");
+    return 1;
+  }
+  if (pid == 0) {
+    const int rc = t->fn();
+    fflush(NULL);
+    _exit(rc == 0 ? 0 : 1);
+  }
+  if (waitpid(pid, &status, 0) != pid) {
+    perror("waitpid");
+    return 1;
+  }
+  if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+    printf("  PASS  %s\n", t->name);
+    return 0;
+  }
+  if (WIFSIGNALED(status)) {
+    printf("  FAIL  %s (uncaught signal %d)\n", t->name, WTERMSIG(status));
+  } else {
+    printf("  FAIL  %s (exit %d)\n", t->name, WEXITSTATUS(status));
+  }
+  return 1;
+}
+
+int main(int argc, char **argv) {
+  const size_t n = sizeof(tests) / sizeof(tests[0]);
+  size_t i;
+  int failures = 0;
+  (void) argc;
+  (void) argv;
+
+  printf("running %zu coffeecatch tests...\n", n);
+  for (i = 0; i < n; i++) {
+    failures += run_forked(&tests[i]);
+  }
+  if (failures == 0) {
+    printf("all %zu tests passed\n", n);
+    return EXIT_SUCCESS;
+  }
+  printf("%d of %zu tests FAILED\n", failures, n);
+  return EXIT_FAILURE;
+}


### PR DESCRIPTION
CoffeeCatch had no tests and no CI. The whole library is signal handling plus `siglongjmp` across threads, the code most likely to break silently, so this adds a real suite and runs it on every push.

`tests.c` covers the catch paths: `SIGSEGV`, a raised `SIGFPE`, `abort()`/`assert`, the assert-true and no-crash pass-throughs, re-entry after a catch, nesting (a crash unwinds to the outermost handler), and `cancel_pending_alarm`. Each case runs in its own forked child, so an uncaught signal or leaked handler state can not take down the runner. The Makefile is modernized alongside so `make check` runs it under any `CC` and CI can inject sanitizer flags. CI drives that Makefile across gcc/clang on x86-64 and arm64, plus a UBSan leg. UBSan runs without ASan on purpose: a library that installs its own `SIGSEGV`/`SIGABRT` handlers and an alternate signal stack can not coexist with ASan's, so every intentional crash dies uncaught under it. macOS is not covered: the ucontext register access and a few signals in coffeecatch.c are Linux/Android-only and do not compile on Darwin, so that is left as a separate porting effort.

Writing the suite surfaced a real bug, left as a follow-up. Concurrent catches on two or more threads reliably kill the process: the handler resets the signal disposition with `signal(code, SIG_DFL)`, which is process-wide, so the first thread to catch disarms the handler for the others. The threads case is committed but skipped with that reason until the core handler is fixed.
