### PR TITLE
Pick the old signal handler by SA_SIGINFO, not by NULL-ness

### DIFF
--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -403,10 +403,15 @@ static void coffeecatch_call_old_signal_handler(const int code, siginfo_t *const
                                                        void * const sc) {
   /* Call the "real" Java handler for JIT and internals. */
   if (code >= 0 && code < SIG_NUMBER_MAX) {
-    if (native_code_g.sa_old[code].sa_sigaction != NULL) {
-      native_code_g.sa_old[code].sa_sigaction(code, si, sc);
-    } else if (native_code_g.sa_old[code].sa_handler != NULL) {
-      native_code_g.sa_old[code].sa_handler(code);
+    const struct sigaction *const sa = &native_code_g.sa_old[code];
+    /* sa_handler and sa_sigaction alias the same union, so SA_SIGINFO decides
+     * which one is live. Neither SIG_DFL (0) nor SIG_IGN (1) is callable. */
+    if ((sa->sa_flags & SA_SIGINFO) != 0) {
+      if (sa->sa_sigaction != NULL) {
+        sa->sa_sigaction(code, si, sc);
+      }
+    } else if (sa->sa_handler != SIG_DFL && sa->sa_handler != SIG_IGN) {
+      sa->sa_handler(code);
     }
   }
 }

--- a/tests.c
+++ b/tests.c
@@ -188,6 +188,44 @@ static NOINLINE int test_cancel_alarm(void) {
   return 0;
 }
 
+/* A pre-existing SIG_IGN must not be called back: SIG_IGN is the constant 1,
+ * not a function. */
+static NOINLINE int test_old_handler_ignore(void) {
+  volatile int caught = 0;
+  CHECK(signal(SIGSEGV, SIG_IGN) != SIG_ERR);
+  COFFEE_TRY() {
+    CRASH();
+  } COFFEE_CATCH() {
+    caught = 1;
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  CHECK(caught);
+  return 0;
+}
+
+static volatile sig_atomic_t old_handler_ran;
+
+static void plain_old_handler(int code) {
+  (void) code;
+  old_handler_ran = 1;
+}
+
+/* A pre-existing handler installed without SA_SIGINFO still gets called. */
+static NOINLINE int test_old_handler_plain(void) {
+  volatile int caught = 0;
+  old_handler_ran = 0;
+  CHECK(signal(SIGSEGV, plain_old_handler) != SIG_ERR);
+  COFFEE_TRY() {
+    CRASH();
+  } COFFEE_CATCH() {
+    caught = 1;
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  CHECK(caught);
+  CHECK(old_handler_ran);
+  return 0;
+}
+
 static NOINLINE void *thread_body(void *arg) {
   volatile int *const caught = (volatile int *) arg;
   COFFEE_TRY() {
@@ -238,6 +276,8 @@ static const struct test tests[] = {
   { "reentry after catch",          test_reentry,     NULL },
   { "nested throws to outermost",   test_nested,      NULL },
   { "cancel_pending_alarm",         test_cancel_alarm, NULL },
+  { "old handler SIG_IGN",          test_old_handler_ignore, NULL },
+  { "old handler without SA_SIGINFO", test_old_handler_plain, NULL },
   /* Reliably kills the process with 2+ threads: the handler resets the signal
    * disposition to SIG_DFL, which is process-wide, so one thread's catch
    * disarms the others. Enable once the core handler is fixed. */


### PR DESCRIPTION
`sa_handler` and `sa_sigaction` are two members of the same union, so testing `sa_sigaction != NULL` to decide which one to call is wrong: it is true for any non-default disposition. If a process had already set `SIG_IGN` on a caught signal, coffeecatch called it, and `SIG_IGN` is the constant 1, so the handler jumped to address 1 and the process died inside its own handler. That is what #34 reports, and why commenting the call out made the crash go away.

The flag `SA_SIGINFO` is what says which union member is live, so test that instead, and skip `SIG_DFL` and `SIG_IGN` since neither is a function.

Two tests cover it: a pre-existing `SIG_IGN` (dies with an uncaught SIGSEGV before this change) and a pre-existing handler without `SA_SIGINFO`, which must still be called.

Closes #34