### PR TITLE
Stop one thread's catch from disarming the others

### DIFF
--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -442,6 +442,11 @@ static void coffeecatch_try_jump_userland(native_code_handler_struct*
 
     /* Invalidate the context */
     t->ctx_is_set = 0;
+#ifdef USE_UNWIND
+    /* Jumping out of the unwinder abandons its frame: disarm the guard, or a
+     * later crash would siglongjmp() into a dead one. */
+    t->unwind_guarded = 0;
+#endif
 
     /* We need to revert the alternate stack before jumping. */
     coffeecatch_revert_alternate_stack();
@@ -525,8 +530,9 @@ static void coffeecatch_fill_backtrace(native_code_handler_struct *const t,
   sigaddset(&unblock, SIGBUS);
   pthread_sigmask(SIG_UNBLOCK, &unblock, &old_mask);
 
-  t->unwind_guarded = 1;
+  /* Arm only once the jump target is stored, never before. */
   if (sigsetjmp(t->unwind_ctx, 1) == 0) {
+    t->unwind_guarded = 1;
     coffeecatch_extract_backtrace(t, si, sc);
   }
   t->unwind_guarded = 0;
@@ -632,6 +638,14 @@ static void coffeecatch_signal_abort(const int code, siginfo_t *const si,
   (void) sc; /* UNUSED */
 
   DEBUG(print("caught abort\n"));
+
+#ifdef USE_UNWIND
+  /* The unwinder aborted (a symbolizer assertion): back out with what we have. */
+  t = coffeecatch_get();
+  if (t != NULL && t->unwind_guarded) {
+    siglongjmp(t->unwind_ctx, 1);
+  }
+#endif
 
   coffeecatch_start_alarm();
 

--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -512,40 +512,18 @@ static void coffeecatch_extract_backtrace(native_code_handler_struct *const t,
 #endif
 }
 
-static native_code_handler_struct* coffeecatch_get(void);
-
-/* siglongjmp target when the unwinder itself faults on a corrupt stack. */
-static void coffeecatch_unwind_guard(const int code, siginfo_t *const si,
-                                     void *const sc) {
-  native_code_handler_struct *const t = coffeecatch_get();
-  (void) si;
-  (void) sc;
-  if (t != NULL && t->unwind_guarded) {
-    siglongjmp(t->unwind_ctx, 1);
-  }
-  /* Not ours to swallow: restore the default fatal disposition. */
-  signal(code, SIG_DFL);
-  raise(code);
-}
-
-/* Unwind under a nested SEGV/BUS guard: a fault inside it keeps the frames
- * gathered so far. The first crash masked the signal: unblock + SA_NODEFER. */
+/* Unwind with t->unwind_guarded armed: if the unwinder faults on a corrupt
+ * stack, the crash handler siglongjmp()s back here with the frames gathered so
+ * far. Entering the handler masked the signal, so unblock it for this thread
+ * only; a process-wide sigaction() here would hijack the other threads. */
 static void coffeecatch_fill_backtrace(native_code_handler_struct *const t,
                                        siginfo_t *const si, void *const sc) {
-  struct sigaction guard, old_segv, old_bus;
   sigset_t unblock, old_mask;
-
-  memset(&guard, 0, sizeof(guard));
-  sigemptyset(&guard.sa_mask);
-  guard.sa_sigaction = coffeecatch_unwind_guard;
-  guard.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER;
-  sigaction(SIGSEGV, &guard, &old_segv);
-  sigaction(SIGBUS, &guard, &old_bus);
 
   sigemptyset(&unblock);
   sigaddset(&unblock, SIGSEGV);
   sigaddset(&unblock, SIGBUS);
-  sigprocmask(SIG_UNBLOCK, &unblock, &old_mask);
+  pthread_sigmask(SIG_UNBLOCK, &unblock, &old_mask);
 
   t->unwind_guarded = 1;
   if (sigsetjmp(t->unwind_ctx, 1) == 0) {
@@ -553,9 +531,7 @@ static void coffeecatch_fill_backtrace(native_code_handler_struct *const t,
   }
   t->unwind_guarded = 0;
 
-  sigprocmask(SIG_SETMASK, &old_mask, NULL);
-  sigaction(SIGSEGV, &old_segv, NULL);
-  sigaction(SIGBUS, &old_bus, NULL);
+  pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 }
 #endif
 
@@ -612,15 +588,20 @@ static void coffeecatch_signal_pass(const int code, siginfo_t *const si,
 
   DEBUG(print("caught signal\n"));
 
+#ifdef USE_UNWIND
+  /* The unwinder faulted on a corrupt stack: back out with what we have. */
+  t = coffeecatch_get();
+  if (t != NULL && t->unwind_guarded) {
+    siglongjmp(t->unwind_ctx, 1);
+  }
+#endif
+
   /* Call the "real" Java handler for JIT and internals. */
   coffeecatch_call_old_signal_handler(code, si, sc);
 
   /* Still here ?
    * FIXME TODO: This is the Dalvik behavior - but is it the SunJVM one ? */
 
-  /* Ensure we do not deadlock. Default of ALRM is to die.
-   * (signal() and alarm() are signal-safe) */
-  signal(code, SIG_DFL);
   coffeecatch_start_alarm();
 
   /* Available context ? */
@@ -652,9 +633,6 @@ static void coffeecatch_signal_abort(const int code, siginfo_t *const si,
 
   DEBUG(print("caught abort\n"));
 
-  /* Ensure we do not deadlock. Default of ALRM is to die.
-   * (signal() and alarm() are signal-safe) */
-  signal(code, SIG_DFL);
   coffeecatch_start_alarm();
 
   /* Available context ? */
@@ -676,6 +654,8 @@ static void coffeecatch_signal_abort(const int code, siginfo_t *const si,
 
   /* Nope. (abort() is signal-safe) */
   DEBUG(print("calling abort()\n"));
+  /* Only now: SIG_DFL is process-wide, and it keeps abort() from re-entering us. */
+  signal(code, SIG_DFL);
   abort();
 }
 

--- a/tests.c
+++ b/tests.c
@@ -226,18 +226,25 @@ static NOINLINE int test_old_handler_plain(void) {
   return 0;
 }
 
+static pthread_barrier_t crash_barrier;
+
 static NOINLINE void *thread_body(void *arg) {
   volatile int *const caught = (volatile int *) arg;
   COFFEE_TRY() {
+    /* Crash only once every thread holds a catch context: a serialized run
+     * would let the handlers be reinstalled between threads, hiding a
+     * process-wide disarm. */
+    pthread_barrier_wait(&crash_barrier);
     CRASH();
   } COFFEE_CATCH() {
-    *caught = 1;
+    *caught = coffeecatch_get_signal() == SIGSEGV ? 1 : -1;
     coffeecatch_cancel_pending_alarm();
   } COFFEE_END();
   return NULL;
 }
 
-/* The handler is documented thread-safe: concurrent catches must all succeed. */
+/* The handler is documented thread-safe: concurrent catches must all succeed,
+ * and each must report its own signal. */
 static NOINLINE int test_threads(void) {
   enum { N = 8 };
   pthread_t th[N];
@@ -246,15 +253,58 @@ static NOINLINE int test_threads(void) {
   for (i = 0; i < N; i++) {
     caught[i] = 0;
   }
+  CHECK(pthread_barrier_init(&crash_barrier, NULL, N) == 0);
   for (i = 0; i < N; i++) {
     CHECK(pthread_create(&th[i], NULL, thread_body, (void *) &caught[i]) == 0);
   }
   for (i = 0; i < N; i++) {
     CHECK(pthread_join(th[i], NULL) == 0);
   }
+  CHECK(pthread_barrier_destroy(&crash_barrier) == 0);
   for (i = 0; i < N; i++) {
-    CHECK(caught[i]);
+    CHECK(caught[i] == 1);
   }
+  return 0;
+}
+
+static volatile int holder_armed;
+
+static NOINLINE void *holder_body(void *arg) {
+  (void) arg;
+  COFFEE_TRY() {
+    holder_armed = 1;
+    for (;;) {
+      usleep(1000);
+    }
+  } COFFEE_CATCH() {
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  return NULL;
+}
+
+/* The give-up path: a crash with no catch context on this thread must still
+ * kill the process, even while another thread keeps the handlers installed. */
+static NOINLINE int test_no_context_dies(void) {
+  pid_t pid;
+  int status = 0;
+
+  fflush(NULL);
+  pid = fork();
+  CHECK(pid >= 0);
+  if (pid == 0) {
+    pthread_t th;
+    pthread_create(&th, NULL, holder_body, NULL);
+    while (!holder_armed) {
+      usleep(1000);
+    }
+    usleep(50000);
+    CRASH();          /* outside any COFFEE_TRY: must not be swallowed */
+    _exit(0);         /* reached only if the crash was wrongly caught */
+  }
+  alarm(20);          /* a handler re-entry loop would hang here */
+  CHECK(waitpid(pid, &status, 0) == pid);
+  alarm(0);
+  CHECK(WIFSIGNALED(status));
   return 0;
 }
 
@@ -279,6 +329,7 @@ static const struct test tests[] = {
   { "old handler SIG_IGN",          test_old_handler_ignore, NULL },
   { "old handler without SA_SIGINFO", test_old_handler_plain, NULL },
   { "concurrent catches (threads)", test_threads, NULL },
+  { "no context: crash still kills", test_no_context_dies, NULL },
 };
 
 static int run_forked(const struct test *t) {

--- a/tests.c
+++ b/tests.c
@@ -278,11 +278,7 @@ static const struct test tests[] = {
   { "cancel_pending_alarm",         test_cancel_alarm, NULL },
   { "old handler SIG_IGN",          test_old_handler_ignore, NULL },
   { "old handler without SA_SIGINFO", test_old_handler_plain, NULL },
-  /* Reliably kills the process with 2+ threads: the handler resets the signal
-   * disposition to SIG_DFL, which is process-wide, so one thread's catch
-   * disarms the others. Enable once the core handler is fixed. */
-  { "concurrent catches (threads)", test_threads,
-    "concurrent catch resets signal disposition process-wide" },
+  { "concurrent catches (threads)", test_threads, NULL },
 };
 
 static int run_forked(const struct test *t) {


### PR DESCRIPTION
Both handlers reset the signal disposition with `signal(code, SIG_DFL)` on entry, and that is process-wide, so the first thread to catch disarmed coffeecatch for every other thread. A second thread faulting inside its own `COFFEE_TRY` then got the default action and killed the process, despite the header promising the handler is thread-safe.

The reset is only really needed on the give-up path, where it stops `abort()` from re-entering its own SIGABRT handler, so that is where it now lives. The per-thread anti-recursion it appeared to provide was already there: `coffeecatch_try_jump_userland()` clears `ctx_is_set` before jumping, so a second crash on the same thread cannot jump again and falls through to `abort()`.

The unwind guard added in #50 turned out to have the same bug, which the skipped test had been hiding. It installed its handler with `sigaction()`, which is process-wide, so while one thread was unwinding, another thread's SIGSEGV landed in the guard, found `unwind_guarded` clear for its own context, and killed the process. The separate guard handler is gone: the crash handler now checks `unwind_guarded` on the current thread and jumps back itself, and only the signal mask is touched, per-thread via `pthread_sigmask()`.

The `concurrent catches (threads)` test (8 threads, each crashing in a `COFFEE_TRY`) was committed as `SKIP` for exactly this bug and is now enabled. I also checked the paths the tests do not reach: a crash or `abort()` on a thread with no catch context still terminates rather than looping, and with a fault injected into the unwinder on every catch the suite still passes, so the guard from #50 still does its job.

Closes #52