### PR TITLE
Document the conventions that only existed in review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+Read `CONTRIBUTING.md` first. It carries the build commands, the
+signal-handler discipline, the platform-gating model, the `COFFEE_TRY` usage
+rules, and the CI rationale, and all of it applies to you. This file adds only
+what an agent gets wrong that a human reader does not.
+
+## Before writing code
+
+Establish whether the code you are touching is Android-only (`USE_UNWIND`,
+`USE_CORKSCREW`, `USE_LIBUNWIND`) or common. Reasoning about `t->frames` in a
+configuration where the member does not exist is the most common wasted pass
+on this repo.
+
+`make check` passing on Linux says nothing about a macOS or Android change.
+State plainly which configurations you actually built, and never describe an
+unbuilt one as working.
+
+## Comments
+
+One line per block by default. Two only if the second earns it. Write them
+terse the first time, then re-read every comment you added and cut before
+showing a diff: delete anything that restates the code, re-derives the bug, or
+narrates how you got there.
+
+This is the most common correction on machine-written patches here.
+
+## Scope
+
+Do one thing. If a build fix would also turn on a new feature, or a new API
+would also restructure the test suite, split the second thing into its own PR
+and say why.
+
+Do not reformat untouched lines, modernize the C89-ish style, or add a
+sanitizer leg to CI without reading why UBSan is alone there.
+
+## Claims
+
+Verify before asserting. If you say it builds, build it. If you say a test
+catches a regression, reintroduce the bug and watch the test fail. An
+unverified claim in a PR description costs more review time than the patch
+saves.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,128 @@
+# Contributing to CoffeeCatch
+
+CoffeeCatch turns fatal POSIX signals into recoverable exceptions. It runs on a
+crash path, inside a signal handler, in a process that is already damaged. A
+bounds, lifetime, or reentrancy bug here is a security bug, not a style nit.
+Please read this file before your first patch.
+
+## Build and test
+
+```sh
+make          # static lib, shared lib, tests, sample
+make check    # build and run the test suite
+```
+
+`tests` and `sample` link the static archive, so there is no `LD_LIBRARY_PATH`
+to set and the run is identical on Linux and macOS.
+
+## Signal-handler discipline
+
+Code reachable from the handler must stay async-signal-safe as far as
+practical. The header documents the two deliberate exceptions the design relies
+on: `siglongjmp()` and `pthread_getspecific()`. Do not add `malloc()` or stdio
+to the handler path.
+
+Signal dispositions are process-wide; coffeecatch's state is per-thread. Never
+use `signal()`/`sigaction()` to express a per-thread decision, or one thread's
+catch disarms every other thread (issue #52). Arm per-thread state instead.
+
+Recovery is `siglongjmp()`, which does not unwind C++ frames or run
+destructors. The model is "log and die", not "recover and continue". The
+`alarm()` armed on catch is a watchdog against deadlocking inside a
+non-signal-safe function; cancelling it is the dangerous operation, not the
+safe one.
+
+## Platform gating
+
+Backtrace support is Android-only by default:
+
+```c
+#ifdef __ANDROID__
+#define USE_UNWIND
+#define USE_CORKSCREW
+#define USE_LIBUNWIND
+#endif
+```
+
+Off Android none of these exist, so the `native_code_handler_struct` `frames[]`
+member and the whole `_Unwind_*` / libcorkscrew / libunwind machinery are
+absent. Anything touching `t->frames`, `frames_size`, or `.absolute_pc` must
+sit inside the matching guard, and `frames[]` is a `backtrace_frame_t` under
+corkscrew but a bare `uintptr_t` under plain unwind. Ask "is this Android-only
+or common?" before writing the code: these configurations compile different
+sources.
+
+## The COFFEE_TRY block
+
+Rules baked into the macros and documented in `coffeecatch.h`:
+
+- No `return` or exit out of the protected block or the handler; cleanup would
+  be skipped.
+- Locals used before the block and read after it must be `volatile`.
+- The enclosing function should be `extern` or `__attribute__((noinline))`.
+- Nested blocks are allowed and throw to the outermost handler. Preserve that
+  if you touch the setup/cleanup path.
+
+## Code style
+
+Portable C89-ish, building clean under `-W -Wall -Wextra -Werror
+-Wno-unused-function`. A warning is a build break: fix the cause rather than
+silencing it with a pragma. Public declarations in the headers carry
+`/** ... **/` Doxygen comments; match that when adding API.
+
+Keep comments to one line per block by default; a second line has to earn its
+place. Comment the why, not the what. Do not narrate the bug you fixed or the
+investigation that found it, in code or in tests. That belongs in the commit
+message.
+
+Format only the lines you touch. This tree does not round-trip cleanly through
+any current formatter, so a whole-file reformat is churn and will be asked for
+removal.
+
+## Tests
+
+`tests.c` is the suite behind `make check`. Each case runs in its own forked
+child, because coffeecatch installs process-global handlers and per-thread
+state, and isolation keeps one case's crash from corrupting the runner.
+Register new cases in the `tests[]` table and confirm they actually ran: a
+silently skipped test is worse than no test.
+
+Any behaviour change needs a test that would catch the regression. When you
+write one, ask what buggy implementation would still pass it. If you can name
+one, the test is not doing its job yet.
+
+## CI
+
+The workflow drives the Makefile directly, since that is what rotted unnoticed
+before:
+
+- build+test matrix over x86-64 and arm64, gcc and clang. The arm64 leg is the
+  closest proxy for the Android arm64 target.
+- a `-DUSE_UNWIND` leg on x86-64, the only coverage the unwind path and its
+  nested-fault guard get outside an NDK build.
+- UBSan only, deliberately. ASan's own signal handling and alternate stack
+  cannot coexist with coffeecatch's handlers and per-thread altstack: every
+  intentional crash then dies uncaught. UBSan installs no handlers. Please do
+  not add an ASan leg.
+- no macOS, and Android is not built at all.
+
+Pull requests from forks need maintainer approval before CI runs, so your first
+push will show no checks until someone approves them.
+
+## Things that bite
+
+- `coffeejni.c` needs `<jni.h>` and is built by neither the Makefile nor CI.
+  "It built" never means the JNI layer built; validate it against an NDK or JDK
+  include path separately.
+- This is Android-first code. Green CI on Linux is a real but partial signal:
+  symbolication and the Bionic `ucontext`/`sigcontext` quirks are exactly what
+  every non-Android leg skips.
+- The two headers are the public surface, consumed downstream as a git
+  submodule. Treat any signature or macro change as an external break: flag it
+  in the PR and expect discussion before it lands.
+
+## Pull requests
+
+Keep the description short: what changed and why. One logical change per PR. If
+your work uncovers a pre-existing bug, file it separately rather than folding
+the fix in.


### PR DESCRIPTION
Writes down the conventions that until now only lived in review comments: the signal-handler discipline, the Android-first platform gating model, the `COFFEE_TRY` usage rules, and why CI runs UBSan alone with no ASan leg.

Two recent contributions made the gap concrete. One widened a macOS build fix into enabling the Android-only unwind path. The other renamed the C test suite wholesale to add C++ cases, which quietly stopped both clang legs from testing clang. Neither was an unreasonable thing to try; both would have been easier to get right against a written convention.

`CLAUDE.md` stays thin and defers to `CONTRIBUTING.md` rather than restating it. It covers only the failure modes specific to automated contributors, mainly reasoning about `frames[]` in a configuration where the member does not exist, and calling a configuration working without having built it.

No code or CI changes.
