### PR TITLE
Balance the reentry count when a signal collapses nested blocks

### DIFF
--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -442,6 +442,9 @@ static void coffeecatch_try_jump_userland(native_code_handler_struct*
 
     /* Invalidate the context */
     t->ctx_is_set = 0;
+    /* Collapse nesting to this outermost block; inner COFFEE_END()s are jumped
+     * over, so only this level's cleanup runs to balance the depth. */
+    t->reenter = 1;
 #ifdef USE_UNWIND
     /* Jumping out of the unwinder abandons its frame: disarm the guard, or a
      * later crash would siglongjmp() into a dead one. */

--- a/tests.c
+++ b/tests.c
@@ -172,6 +172,7 @@ static NOINLINE int test_nested(void) {
   CHECK(outer_caught);
   CHECK(!inner_caught);
   CHECK(!outer_after);
+  CHECK(!coffeecatch_inside());   /* nesting depth balanced back to zero */
   return 0;
 }
 


### PR DESCRIPTION
What
A signal caught inside a nested COFFEE_TRY block leaves the thread's reentry count unbalanced, wedging it as permanently "inside" a protected section. This resets the count at the point where the nesting collapses.

Why
Only the outermost COFFEE_TRY ever calls coffeecatch_setup()/sigsetjmp() — an inner block short-circuits on coffeecatch_inside() and saves no context of its own. So a caught signal always siglongjmp()s straight to the outermost level, and the inner COFFEE_END()s are jumped over.

But t->reenter was incremented once per nesting level and is only decremented by the single outermost cleanup that runs afterward. A crash caught two levels deep therefore returns with reenter == 1 instead of 0. The thread is now stuck: the next top-level COFFEE_TRY() is misread as nested, so it installs no fresh sigsetjmp context, and its own crash siglongjmp()s nowhere.

This is independent of the "log and die" model — it only bites callers who cancel the alarm and continue after a nested catch, but for them the thread is silently unusable.

Fix
Reset t->reenter = 1 in coffeecatch_try_jump_userland, right where the context is invalidated before the jump. Since the jump always lands at the outermost level, 1 is unconditionally correct: the single cleanup that runs then balances it to 0. It's a plain int store, so it stays async-signal-safe, and the documented "nested blocks throw to the outermost handler" behavior is unchanged.

Test
test_nested now asserts !coffeecatch_inside() after the outer block — the depth must return to zero. Confirmed it fails against the unfixed library and passes with the fix.

Verification
make check green on gcc, clang, the -DUSE_UNWIND leg, and UBSan (Linux x86-64).