### PR TITLE
Fix strerror_r handling on the si_errno message path (#59)

### DIFF
--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -1312,12 +1312,21 @@ const char* coffeecatch_get_message() {
     if (t->si.si_errno != 0) {
       snprintf(&buffer[buffer_offs], buffer_len - buffer_offs, ": ");
       buffer_offs += strlen(&buffer[buffer_offs]);
-      if (strerror_r(t->si.si_errno, &buffer[buffer_offs],
-                     buffer_len - buffer_offs) == 0) {
+      const char* err_str = "unknown error";
+      if (
+#if defined(__GLIBC__) && defined(_GNU_SOURCE)
+          (err_str = strerror_r(t->si.si_errno, &buffer[buffer_offs],
+                     buffer_len - buffer_offs)) != &buffer[buffer_offs]
+#else
+
+          strerror_r(t->si.si_errno, &buffer[buffer_offs],
+                     buffer_len - buffer_offs) != 0
+#endif
+      ) {
         snprintf(&buffer[buffer_offs], buffer_len - buffer_offs,
-                 "unknown error");
-        buffer_offs += strlen(&buffer[buffer_offs]);
+                 "%s", err_str);
       }
+      buffer_offs += strlen(&buffer[buffer_offs]);
     }
 
     /* Sending process ID. */

--- a/tests.c
+++ b/tests.c
@@ -326,8 +326,7 @@ static struct sigaction errno_cc_action;
 static volatile int errno_to_inject;
 
 /* Chain ahead of coffeecatch: stamp si_errno (the kernel never sets it for the
- * faults we catch, so it is otherwise unreachable) and hand off to the real
- * handler, which copies the siginfo and reports it in the message. */
+ * faults we can synthesize) and hand off to the real handler. */
 static void errno_shim(int sig, siginfo_t *si, void *uc) {
   si->si_errno = errno_to_inject;
   errno_cc_action.sa_sigaction(sig, si, uc);
@@ -340,13 +339,12 @@ static NOINLINE int check_errno_message(int err) {
   errno_to_inject = err;
   COFFEE_TRY() {
     /* coffeecatch's handler is installed now; capture it and insert the shim. */
-    struct sigaction shim;
-    sigaction(SIGSEGV, NULL, &errno_cc_action);
-    memset(&shim, 0, sizeof shim);
-    shim.sa_sigaction = errno_shim;
-    shim.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    struct sigaction shim = {
+      .sa_sigaction = errno_shim,
+      .sa_flags = SA_SIGINFO | SA_ONSTACK,
+    };
     sigemptyset(&shim.sa_mask);
-    sigaction(SIGSEGV, &shim, NULL);
+    sigaction(SIGSEGV, &shim, &errno_cc_action);
     CRASH();
   } COFFEE_CATCH() {
     const char *const msg = coffeecatch_get_message();

--- a/tests.c
+++ b/tests.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <signal.h>
 #include <stdint.h>
+#include <errno.h>
 #include <pthread.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -321,6 +322,48 @@ static NOINLINE int test_no_context_dies(void) {
   return 0;
 }
 
+static struct sigaction errno_cc_action;
+static volatile int errno_to_inject;
+
+/* Chain ahead of coffeecatch: stamp si_errno (the kernel never sets it for the
+ * faults we catch, so it is otherwise unreachable) and hand off to the real
+ * handler, which copies the siginfo and reports it in the message. */
+static void errno_shim(int sig, siginfo_t *si, void *uc) {
+  si->si_errno = errno_to_inject;
+  errno_cc_action.sa_sigaction(sig, si, uc);
+}
+
+/* A signal carrying si_errno reports that errno's description, and does not
+ * lose it to the text appended afterwards -- the two bugs from issue #59. */
+static NOINLINE int check_errno_message(int err) {
+  volatile int caught = 0, ok = 0;
+  errno_to_inject = err;
+  COFFEE_TRY() {
+    /* coffeecatch's handler is installed now; capture it and insert the shim. */
+    struct sigaction shim;
+    sigaction(SIGSEGV, NULL, &errno_cc_action);
+    memset(&shim, 0, sizeof shim);
+    shim.sa_sigaction = errno_shim;
+    shim.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    sigemptyset(&shim.sa_mask);
+    sigaction(SIGSEGV, &shim, NULL);
+    CRASH();
+  } COFFEE_CATCH() {
+    const char *const msg = coffeecatch_get_message();
+    /* strerror() at runtime, so the match survives platform wording. */
+    ok = msg != NULL && strstr(msg, strerror(err)) != NULL;
+    caught = 1;
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  return caught && ok;
+}
+
+static NOINLINE int test_errno_message(void) {
+  CHECK(check_errno_message(EACCES));
+  CHECK(check_errno_message(EINVAL));
+  return 0;
+}
+
 /* --- fork harness -------------------------------------------------------- */
 
 struct test {
@@ -343,6 +386,7 @@ static const struct test tests[] = {
   { "old handler without SA_SIGINFO", test_old_handler_plain, NULL },
   { "concurrent catches (threads)", test_threads, NULL },
   { "no context: crash still kills", test_no_context_dies, NULL },
+  { "si_errno in message",          test_errno_message, NULL },
 };
 
 static int run_forked(const struct test *t) {


### PR DESCRIPTION
Fixes #59.

`coffeecatch_get_message()` assumed the GNU `strerror_r` at the `si_errno`
branch: the `== 0` test never fires on glibc (it returns `char*`), and on
Darwin/Bionic `0` means success, so a good lookup wrote `"unknown error"` over
the real text. A second, variant-independent bug sat underneath: `buffer_offs`
was advanced only for the placeholder, so a message `strerror_r` wrote into the
buffer itself was clobbered by the faulting-PC text appended after.

Fix: gate the variant on `__GLIBC__ && _GNU_SOURCE` (matching the sibling call
from #55), invert the success/failure logic per variant, and advance
`buffer_offs` unconditionally.

The branch is normally unreachable — the kernel never sets `si_errno` for these
faults and no portable API injects it. `test_errno_message` gets there with
public API only: a shim chained inside `COFFEE_TRY()` stamps `si_errno` and
forwards to coffeecatch's handler, then the message is matched against
`strerror()`. It fails against pre-fix `coffeecatch.c`.

Verified on macOS arm64 and Linux gcc/clang (default, `-DUSE_UNWIND`, UBSan).
Pre-existing on master, independent of the open macOS PRs.