### PR TITLE
Tolerate a missing context in coffeecatch_cleanup() (#57)

### DIFF
--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -1460,8 +1460,11 @@ int coffeecatch_setup() {
  */
 void coffeecatch_cleanup() {
   native_code_handler_struct *const t = coffeecatch_get();
-  assert(t != NULL);
-  assert(t->reenter > 0);
+  /* COFFEE_END() runs even when coffeecatch_setup() failed and no context was
+     entered (t == NULL on alloc failure, reenter == 0 on global-install failure). */
+  if (t == NULL || t->reenter == 0) {
+    return;
+  }
   t->reenter--;
   if (t->reenter == 0) {
     t->ctx_is_set = 0;

--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -1460,11 +1460,12 @@ int coffeecatch_setup() {
  */
 void coffeecatch_cleanup() {
   native_code_handler_struct *const t = coffeecatch_get();
-  /* COFFEE_END() runs even when coffeecatch_setup() failed and no context was
-     entered (t == NULL on alloc failure, reenter == 0 on global-install failure). */
-  if (t == NULL || t->reenter == 0) {
+  /* COFFEE_END() runs even when coffeecatch_setup() failed: the per-thread
+     context was never allocated, so t is NULL and there is nothing to undo. */
+  if (t == NULL) {
     return;
   }
+  assert(t->reenter > 0);
   t->reenter--;
   if (t->reenter == 0) {
     t->ctx_is_set = 0;

--- a/tests.c
+++ b/tests.c
@@ -362,6 +362,13 @@ static NOINLINE int test_errno_message(void) {
   return 0;
 }
 
+/* COFFEE_END() (== coffeecatch_cleanup) fires even when coffeecatch_setup()
+ * failed: no per-thread context exists, so t is NULL. Pre-#57 this NULL-derefs. */
+static NOINLINE int test_cleanup_no_setup(void) {
+  coffeecatch_cleanup();   /* COFFEE_END() with no established context */
+  return 0;                /* not crashing is the pass */
+}
+
 /* --- fork harness -------------------------------------------------------- */
 
 struct test {
@@ -385,6 +392,7 @@ static const struct test tests[] = {
   { "concurrent catches (threads)", test_threads, NULL },
   { "no context: crash still kills", test_no_context_dies, NULL },
   { "si_errno in message",          test_errno_message, NULL },
+  { "cleanup without setup",        test_cleanup_no_setup, NULL },
 };
 
 static int run_forked(const struct test *t) {


### PR DESCRIPTION
coffeecatch_setup() can fail (allocation failure, or a failed global handler install), which leaves COFFEE_TRY()'s condition false and drops control into COFFEE_CATCH(). COFFEE_END() then runs coffeecatch_cleanup() unconditionally, which asserted a non-NULL context and decremented its reenter count: a NULL dereference when setup never established one. Under -DNDEBUG, which ndk-build ships, the asserts compile out and it becomes a silent NULL write, so the Android release path is the one that gets it.

Return early when setup left no per-thread context to clean up (t == NULL). The added test drives COFFEE_END() with no matching COFFEE_TRY and crashes on master in both debug (assert, SIGABRT) and release (NULL write, SIGSEGV) builds.

A related latent bug is out of scope here and tracked separately in #66: when setup fails after the global handlers are installed, those handlers are not rolled back, so this early return leaves them installed rather than torn down. That is a gap in coffeecatch_handler_setup, not in cleanup.

Closes #57.