### PR TITLE
strerror_r: select the GNU variant by libc, not just __GLIBC__ (#63)

### DIFF
--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -65,6 +65,13 @@
 #include <dlfcn.h>
 #include "coffeecatch.h"
 
+/* strerror_r has two forms: the GNU one returns char* (glibc and bionic API>=23
+   select it under _GNU_SOURCE), the XSI one returns int (musl, Darwin, default). */
+#if defined(_GNU_SOURCE) \
+    && (defined(__GLIBC__) || (defined(__BIONIC__) && __ANDROID_API__ >= 23))
+#define COFFEE_STRERROR_R_CHAR 1
+#endif
+
 /*#define NDK_DEBUG 1*/
 #if ( defined(NDK_DEBUG) && ( NDK_DEBUG == 1 ) )
 #define DEBUG(A) do { A; } while(0)
@@ -1314,7 +1321,7 @@ const char* coffeecatch_get_message() {
       buffer_offs += strlen(&buffer[buffer_offs]);
       const char* err_str = "unknown error";
       if (
-#if defined(__GLIBC__) && defined(_GNU_SOURCE)
+#if defined(COFFEE_STRERROR_R_CHAR)
           (err_str = strerror_r(t->si.si_errno, &buffer[buffer_offs],
                      buffer_len - buffer_offs)) != &buffer[buffer_offs]
 #else
@@ -1350,7 +1357,7 @@ const char* coffeecatch_get_message() {
   } else {
     /* Static buffer in case of emergency */
     static char buffer[256];
-#if defined(__GLIBC__) && defined(_GNU_SOURCE)
+#if defined(COFFEE_STRERROR_R_CHAR)
     return strerror_r(error, &buffer[0], sizeof(buffer));
 #else
     const int code = strerror_r(error, &buffer[0], sizeof(buffer));

--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -69,7 +69,7 @@
    select it under _GNU_SOURCE), the XSI one returns int (musl, Darwin, default). */
 #if defined(_GNU_SOURCE) \
     && (defined(__GLIBC__) || (defined(__BIONIC__) && __ANDROID_API__ >= 23))
-#define COFFEE_STRERROR_R_CHAR 1
+#define COFFEE_STRERROR_R_CHAR
 #endif
 
 /*#define NDK_DEBUG 1*/


### PR DESCRIPTION
Both `strerror_r` call sites gated the GNU (`char*`) versus XSI (`int`) form on `__GLIBC__ && _GNU_SOURCE`. Bionic also returns the GNU form under `_GNU_SOURCE` on API >= 23 but does not define `__GLIBC__`, so an Android build took the `int` arm against a `char*`-returning call and wrote "unknown error" over every real message. Impact is small in practice (the kernel leaves `si_errno == 0` for the faults caught, so that path is normally unreachable, and the sibling site only runs on setup failure), but the gate was wrong on the primary target.

The choice now lives in one `COFFEE_STRERROR_R_CHAR` macro (glibc, or bionic API >= 23) used at both sites. glibc, musl, and Darwin behavior is unchanged, and the existing `si_errno` test still covers the glibc `char*` path. No CI leg builds Android, so the bionic arm is verified by evaluating the gate through the preprocessor rather than at runtime.

Closes #63.
