### PR TITLE
Roll back the global handlers when thread-local setup fails (#66)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,15 @@ $(SHLIB): $(LIBOBJ)
 
 # tests/sample link the static archive: no LD_LIBRARY_PATH, identical run on
 # Linux and macOS. The C suite links with $(CC), the C++ suite with $(CXX).
-tests: tests.o $(STATICLIB)
-	$(CC) $(CFLAGS) $< $(STATICLIB) -o $@ $(LDFLAGS) $(LDLIBS)
+# The C suite links an instrumented coffeecatch instead of the archive:
+# -DCOFFEE_TESTING adds a failure-injection seam for the setup-failure test and
+# stays out of the shipped $(STATICLIB)/$(SHLIB).
+tests.o: tests.c coffeecatch.h
+	$(CC) $(CPPFLAGS) -DCOFFEE_TESTING $(CFLAGS) -c $< -o $@
+coffeecatch-testing.o: coffeecatch.c coffeecatch.h
+	$(CC) $(CPPFLAGS) -DCOFFEE_TESTING $(CFLAGS) -c $< -o $@
+tests: tests.o coffeecatch-testing.o
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS) $(LDLIBS)
 tests_cxx: tests_cxx.o $(STATICLIB)
 	$(CXX) $(CXXFLAGS) $< $(STATICLIB) -o $@ $(LDFLAGS) $(LDLIBS)
 sample: sample.o $(STATICLIB)

--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -785,8 +785,8 @@ static int coffeecatch_native_code_handler_struct_free(native_code_handler_struc
  * Create a native_code_handler_struct structure.
  **/
 #ifdef COFFEE_TESTING
-/* Test seam (#66): when nonzero, the per-thread init fails, so the setup-failure
-   rollback can be exercised deterministically. Defined only in the test build. */
+/* Test seam (#66): when nonzero, the per-thread init fails so the setup-failure
+   rollback can be exercised. */
 int coffeecatch_test_force_alloc_failure = 0;
 #endif
 

--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -784,11 +784,23 @@ static int coffeecatch_native_code_handler_struct_free(native_code_handler_struc
 /**
  * Create a native_code_handler_struct structure.
  **/
+#ifdef COFFEE_TESTING
+/* Test seam (#66): when nonzero, the per-thread init fails, so the setup-failure
+   rollback can be exercised deterministically. Defined only in the test build. */
+int coffeecatch_test_force_alloc_failure = 0;
+#endif
+
 static native_code_handler_struct* coffeecatch_native_code_handler_struct_init(void) {
   stack_t stack;
-  native_code_handler_struct *const t =
-    calloc(1, sizeof(native_code_handler_struct));
+  native_code_handler_struct *t;
 
+#ifdef COFFEE_TESTING
+  if (coffeecatch_test_force_alloc_failure) {
+    return NULL;
+  }
+#endif
+
+  t = calloc(1, sizeof(native_code_handler_struct));
   if (t == NULL) {
     return NULL;
   }
@@ -822,6 +834,8 @@ static native_code_handler_struct* coffeecatch_native_code_handler_struct_init(v
   return t;
 }
 
+static int coffeecatch_handler_cleanup(void);
+
 /**
  * Acquire the crash handler for the current thread.
  * The coffeecatch_handler_cleanup() must be called to release allocated
@@ -851,7 +865,10 @@ static int coffeecatch_handler_setup(int setup_thread) {
     native_code_handler_struct *const t =
       coffeecatch_native_code_handler_struct_init();
 
+    /* The global install above bumped the refcount; undo it so a failed setup
+       does not leave the handlers installed for the life of the process (#66). */
     if (t == NULL) {
+      coffeecatch_handler_cleanup();
       return -1;
     }
 
@@ -860,6 +877,7 @@ static int coffeecatch_handler_setup(int setup_thread) {
     /* Set thread-specific value. */
     if (pthread_setspecific(native_code_thread, t) != 0) {
       coffeecatch_native_code_handler_struct_free(t);
+      coffeecatch_handler_cleanup();
       return -1;
     }
 

--- a/tests.c
+++ b/tests.c
@@ -369,6 +369,23 @@ static NOINLINE int test_cleanup_no_setup(void) {
   return 0;                /* not crashing is the pass */
 }
 
+#ifdef COFFEE_TESTING
+/* A setup() that fails at the per-thread alloc must roll back the global install
+ * (#66): the SIGSEGV disposition is left as it was, not with coffeecatch's
+ * SA_SIGINFO handler leaked in place. */
+extern int coffeecatch_test_force_alloc_failure;
+static NOINLINE int test_setup_failure_rolls_back(void) {
+  struct sigaction before, after;
+  CHECK(sigaction(SIGSEGV, NULL, &before) == 0);
+  coffeecatch_test_force_alloc_failure = 1;
+  CHECK(coffeecatch_setup() != 0);
+  coffeecatch_test_force_alloc_failure = 0;
+  CHECK(sigaction(SIGSEGV, NULL, &after) == 0);
+  CHECK((after.sa_flags & SA_SIGINFO) == (before.sa_flags & SA_SIGINFO));
+  return 0;
+}
+#endif
+
 /* --- fork harness -------------------------------------------------------- */
 
 struct test {
@@ -393,6 +410,9 @@ static const struct test tests[] = {
   { "no context: crash still kills", test_no_context_dies, NULL },
   { "si_errno in message",          test_errno_message, NULL },
   { "cleanup without setup",        test_cleanup_no_setup, NULL },
+#ifdef COFFEE_TESTING
+  { "setup failure rolls back",     test_setup_failure_rolls_back, NULL },
+#endif
 };
 
 static int run_forked(const struct test *t) {

--- a/tests.c
+++ b/tests.c
@@ -371,8 +371,7 @@ static NOINLINE int test_cleanup_no_setup(void) {
 
 #ifdef COFFEE_TESTING
 /* A setup() that fails at the per-thread alloc must roll back the global install
- * (#66): the SIGSEGV disposition is left as it was, not with coffeecatch's
- * SA_SIGINFO handler leaked in place. */
+ * (#66): the SIGSEGV disposition is restored, not left as coffeecatch's handler. */
 extern int coffeecatch_test_force_alloc_failure;
 static NOINLINE int test_setup_failure_rolls_back(void) {
   struct sigaction before, after;


### PR DESCRIPTION
coffeecatch_handler_setup() installs the process-wide handlers and bumps the refcount before it allocates the per-thread struct, but returned -1 on a failed allocation (or pthread_setspecific) without undoing that global side. The handlers then leaked for the life of the process, and COFFEE_END()'s early return (from #64) never balanced the count. Both failure paths now call coffeecatch_handler_cleanup(), which with no per-thread context set does only the refcount-guarded global teardown.

Reaching this path needs an allocation failure, so the test uses a COFFEE_TESTING-only seam that forces the per-thread init to fail, then checks the SIGSEGV disposition is restored rather than left as coffeecatch's handler. The seam compiles only into the test binary, not the shipped .a or .so. The pthread_setspecific path runs the identical rollback and is covered by inspection, since that call cannot be made to fail deterministically.

Closes #66.