### PR TITLE
Darwin: frame-pointer backtrace support

### DIFF
--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -31,8 +31,13 @@
 #define USE_LIBUNWIND
 #endif
 
-/* __APPLE__ deliberately does not enable USE_UNWIND: _Unwind_Backtrace() in the
- * handler takes the dyld loader lock per frame on Darwin and can self-deadlock. */
+/* Darwin cannot use _Unwind_Backtrace() in the handler: it takes the dyld
+ * loader lock per frame and would self-deadlock on a crash holding that lock.
+ * Walk the frame-pointer chain instead (async-signal-safe, pure reads). */
+#ifdef __APPLE__
+#define USE_UNWIND
+#define USE_FRAMEPOINTER
+#endif
 
 /* #undef NO_USE_SIGALTSTACK */
 /* #undef USE_SILENT_SIGALTSTACK */
@@ -51,7 +56,7 @@
     defined(__arm__) && !defined(__BIONIC_HAVE_STRUCT_SIGCONTEXT)
 #include <asm/sigcontext.h>
 #endif 
-#if (defined(USE_UNWIND) && !defined(USE_CORKSCREW))
+#if (defined(USE_UNWIND) && !defined(USE_CORKSCREW) && !defined(USE_FRAMEPOINTER))
 #include <unwind.h>
 /* "Continue unwinding" is _URC_OK on ARM EHABI, _URC_NO_REASON on the Itanium
  * ABI; both are 0, and both are enum constants #if cannot see -- so gate on ABI. */
@@ -277,7 +282,7 @@ static native_code_global_struct native_code_g =
 /* Thread variable holding context. */
 pthread_key_t native_code_thread;
 
-#if (defined(USE_UNWIND) && !defined(USE_CORKSCREW))
+#if (defined(USE_UNWIND) && !defined(USE_CORKSCREW) && !defined(USE_FRAMEPOINTER))
 /* Unwind callback */
 static _Unwind_Reason_Code
 coffeecatch_unwind_callback(struct _Unwind_Context* context, void* arg) {
@@ -497,6 +502,68 @@ static void coffeecatch_mark_alarm(native_code_handler_struct *const t) {
 }
 
 #ifdef USE_UNWIND
+#ifdef USE_FRAMEPOINTER
+/* Walk the frame-pointer chain from the trapping context. Both the arm64 and
+ * x86-64 ABIs store [saved fp][return address] at the frame pointer, so one
+ * loop covers both. Pure memory reads keep it async-signal-safe; a garbage
+ * link faults into the unwind_guarded jump rather than reading wild memory. */
+static void coffeecatch_fp_backtrace(native_code_handler_struct *const t,
+                                     void *const sc) {
+  const ucontext_t *const uc = (const ucontext_t*) sc;
+  uintptr_t fp;
+#if defined(__aarch64__)
+  /* If the trapping function is a leaf, it has not spilled its return address,
+   * so the immediate caller lives only in LR, not in the frame chain. */
+  uintptr_t lr;
+#endif
+
+  t->frames_size = 0;
+  if (uc == NULL) {
+    return;
+  }
+#if defined(__aarch64__)
+  t->frames[t->frames_size++] = (uintptr_t) uc->uc_mcontext->__ss.__pc;
+  lr = (uintptr_t) uc->uc_mcontext->__ss.__lr;
+  fp = (uintptr_t) uc->uc_mcontext->__ss.__fp;
+#elif defined(__x86_64__)
+  t->frames[t->frames_size++] = (uintptr_t) uc->uc_mcontext->__ss.__rip;
+  fp = (uintptr_t) uc->uc_mcontext->__ss.__rbp;
+#else
+#error "USE_FRAMEPOINTER: unsupported architecture"
+#endif
+
+  /* Require each frame pointer to climb and stay word-aligned, so a corrupt
+   * link ends the walk instead of chasing it. */
+  while (fp != 0 && (fp & (sizeof(uintptr_t) - 1)) == 0
+         && t->frames_size < BACKTRACE_FRAMES_MAX) {
+    const uintptr_t *const frame = (const uintptr_t*) fp;
+    const uintptr_t next_fp = frame[0];
+    const uintptr_t ret = frame[1];
+#if defined(__aarch64__)
+    /* Emit LR once, ahead of the first spilled return address, unless the
+     * frame already spilled that same value (non-leaf) -- then it would
+     * duplicate the entry the walk is about to add. */
+    if (lr != 0) {
+      if (lr != ret) {
+        t->frames[t->frames_size++] = lr;
+      }
+      lr = 0;
+      if (t->frames_size == BACKTRACE_FRAMES_MAX) {
+        break;
+      }
+    }
+#endif
+    if (ret != 0) {
+      t->frames[t->frames_size++] = ret;
+    }
+    if (next_fp <= fp) {
+      break;
+    }
+    fp = next_fp;
+  }
+}
+#endif
+
 /* May fault on a corrupt stack: only run under coffeecatch_fill_backtrace(). */
 static void coffeecatch_extract_backtrace(native_code_handler_struct *const t,
                                           siginfo_t *const si, void *const sc) {
@@ -510,6 +577,10 @@ static void coffeecatch_extract_backtrace(native_code_handler_struct *const t,
 #ifdef USE_CORKSCREW
   t->frames_size = coffeecatch_backtrace_signal(si, sc, t->frames, 0,
                                                 BACKTRACE_FRAMES_MAX);
+#elif defined(USE_FRAMEPOINTER)
+  (void) si;
+  /* Seeded from the signal context, so no frames to skip. */
+  coffeecatch_fp_backtrace(t, sc);
 #else
   (void) si;
   (void) sc;

--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -506,16 +506,17 @@ static void coffeecatch_mark_alarm(native_code_handler_struct *const t) {
 /* Walk the frame-pointer chain from the trapping context. Both the arm64 and
  * x86-64 ABIs store [saved fp][return address] at the frame pointer, so one
  * loop covers both. Pure memory reads keep it async-signal-safe; a garbage
- * link faults into the unwind_guarded jump rather than reading wild memory. */
+ * link faults into the unwind_guarded jump rather than reading wild memory.
+ *
+ * A frameless leaf (one that makes no calls) never spills its return address,
+ * so its immediate caller lives only in LR and is not recovered here -- the
+ * walk resumes from the caller's frame. LR is not consulted: once a function
+ * has made any call, LR holds a stale in-function address a frame walk cannot
+ * tell from a real return, so a missing frame is preferred to a fabricated one. */
 static void coffeecatch_fp_backtrace(native_code_handler_struct *const t,
                                      void *const sc) {
   const ucontext_t *const uc = (const ucontext_t*) sc;
   uintptr_t fp;
-#if defined(__aarch64__)
-  /* If the trapping function is a leaf, it has not spilled its return address,
-   * so the immediate caller lives only in LR, not in the frame chain. */
-  uintptr_t lr;
-#endif
 
   t->frames_size = 0;
   if (uc == NULL) {
@@ -523,7 +524,6 @@ static void coffeecatch_fp_backtrace(native_code_handler_struct *const t,
   }
   t->frames[t->frames_size++] = t->pc;
 #if defined(__aarch64__)
-  lr = (uintptr_t) uc->uc_mcontext->__ss.__lr;
   fp = (uintptr_t) uc->uc_mcontext->__ss.__fp;
 #elif defined(__x86_64__)
   fp = (uintptr_t) uc->uc_mcontext->__ss.__rbp;
@@ -538,20 +538,6 @@ static void coffeecatch_fp_backtrace(native_code_handler_struct *const t,
     const uintptr_t *const frame = (const uintptr_t*) fp;
     const uintptr_t next_fp = frame[0];
     const uintptr_t ret = frame[1];
-#if defined(__aarch64__)
-    /* Emit LR once, ahead of the first spilled return address, unless the
-     * frame already spilled that same value (non-leaf) -- then it would
-     * duplicate the entry the walk is about to add. */
-    if (lr != 0) {
-      if (lr != ret) {
-        t->frames[t->frames_size++] = lr;
-      }
-      lr = 0;
-      if (t->frames_size == BACKTRACE_FRAMES_MAX) {
-        break;
-      }
-    }
-#endif
     if (ret != 0) {
       t->frames[t->frames_size++] = ret;
     }

--- a/coffeecatch.c
+++ b/coffeecatch.c
@@ -521,12 +521,11 @@ static void coffeecatch_fp_backtrace(native_code_handler_struct *const t,
   if (uc == NULL) {
     return;
   }
+  t->frames[t->frames_size++] = t->pc;
 #if defined(__aarch64__)
-  t->frames[t->frames_size++] = (uintptr_t) uc->uc_mcontext->__ss.__pc;
   lr = (uintptr_t) uc->uc_mcontext->__ss.__lr;
   fp = (uintptr_t) uc->uc_mcontext->__ss.__fp;
 #elif defined(__x86_64__)
-  t->frames[t->frames_size++] = (uintptr_t) uc->uc_mcontext->__ss.__rip;
   fp = (uintptr_t) uc->uc_mcontext->__ss.__rbp;
 #else
 #error "USE_FRAMEPOINTER: unsupported architecture"

--- a/tests.c
+++ b/tests.c
@@ -385,6 +385,59 @@ static NOINLINE int test_setup_failure_rolls_back(void) {
 }
 #endif
 
+/* Backtrace capture is only compiled in where coffeecatch collects frames:
+ * Darwin's frame-pointer walk, and the -DUSE_UNWIND builds (Android, CI leg). */
+#if defined(__APPLE__) || defined(USE_UNWIND)
+#define HAVE_BACKTRACE
+#endif
+
+static volatile sig_atomic_t bt_saw_crash, bt_saw_mid;
+
+static void bt_cb(void *arg, const char *module, uintptr_t addr,
+                  const char *function, uintptr_t offset) {
+  (void) arg; (void) module; (void) addr; (void) offset;
+  if (function != NULL) {
+    if (strcmp(function, "bt_crash") == 0) bt_saw_crash = 1;
+    if (strcmp(function, "bt_mid") == 0)   bt_saw_mid = 1;
+  }
+}
+
+static volatile int bt_sink;
+static NOINLINE void bt_crash(void) { CRASH(); }
+/* bt_sink++ after the call keeps bt_mid from tail-calling bt_crash, so it holds
+ * a real frame the walk must recover. On arm64 that frame is reachable only via
+ * LR (bt_crash faults as a leaf), so this also exercises the LR seeding. */
+static NOINLINE void bt_mid(void) { bt_crash(); bt_sink++; }
+
+/* A caught crash exposes a backtrace naming the frames that led to it. */
+static NOINLINE int test_backtrace(void) {
+  volatile int caught = 0;
+  volatile size_t size = 0;
+  bt_saw_crash = 0;
+  bt_saw_mid = 0;
+  COFFEE_TRY() {
+    bt_mid();
+  } COFFEE_CATCH() {
+    caught = 1;
+    size = coffeecatch_get_backtrace_size();
+    coffeecatch_get_backtrace_info(bt_cb, NULL);
+    coffeecatch_cancel_pending_alarm();
+  } COFFEE_END();
+  CHECK(caught);
+#if defined(__APPLE__)
+  /* The frame-pointer walk is what this feature adds: verify it reaches past
+   * the faulting leaf to its caller, and that both symbolize. */
+  CHECK(size > 0);
+  CHECK(bt_saw_crash);
+  CHECK(bt_saw_mid);
+#elif defined(HAVE_BACKTRACE)
+  CHECK(size > 0);        /* unwind path present; symbol names not guaranteed */
+#else
+  CHECK(size == 0);       /* no collector compiled in */
+#endif
+  return 0;
+}
+
 /* --- fork harness -------------------------------------------------------- */
 
 struct test {
@@ -412,6 +465,7 @@ static const struct test tests[] = {
 #ifdef COFFEE_TESTING
   { "setup failure rolls back",     test_setup_failure_rolls_back, NULL },
 #endif
+  { "backtrace names the frames",   test_backtrace,   NULL },
 };
 
 static int run_forked(const struct test *t) {

--- a/tests.c
+++ b/tests.c
@@ -441,7 +441,10 @@ static NOINLINE int check_backtrace(int in_leaf) {
   CHECK(size > 2);
 #if defined(HAVE_BACKTRACE_NAMES)
   CHECK(bt_saw_crash == 1);
-  CHECK(bt_saw_mid);
+#if defined(__arm64__)
+  if (!in_leaf) /* bt_mid() won't appear for aarch64; leaf lacks stack frame */
+#endif
+    CHECK(bt_saw_mid);
 #endif
   return 0;
 }

--- a/tests.c
+++ b/tests.c
@@ -412,13 +412,13 @@ static NOINLINE void bt_crash_leaf(void) { CRASH(); }
 static NOINLINE void bt_mid(int in_leaf) {
 #if defined (__aarch64__)
   if (in_leaf) {
-    bt_crash_leaf(); /* crash in leaf; use LR to recover crash site. */
+    bt_crash_leaf(); /* crash in leaf; BT will skip immediate caller. */
   } else
 #else
   (void)in_leaf;
 #endif
   {
-    bt_crash(); /* aarch64: crash in non-leaf; LR -> spurious bt entry. */
+    bt_crash(); /* aarch64: crash in non-leaf, all callers present. */
   }
   bt_sink++; /* prevent tail-call to crash(), generating recoverable frame. */
  }

--- a/tests.c
+++ b/tests.c
@@ -385,10 +385,13 @@ static NOINLINE int test_setup_failure_rolls_back(void) {
 }
 #endif
 
-/* Backtrace capture is only compiled in where coffeecatch collects frames:
- * Darwin's frame-pointer walk, and the -DUSE_UNWIND builds (Android, CI leg). */
-#if defined(__APPLE__) || defined(USE_UNWIND)
+#if defined(__ANDROID__) || defined(__APPLE__) || defined(USE_UNWIND)
 #define HAVE_BACKTRACE
+#endif
+
+#if defined(HAVE_BACKTRACE)
+#if defined(__ANDROID__) || defined(__APPLE__)
+#define HAVE_BACKTRACE_NAMES
 #endif
 
 static volatile sig_atomic_t bt_saw_crash, bt_saw_mid;
@@ -397,26 +400,37 @@ static void bt_cb(void *arg, const char *module, uintptr_t addr,
                   const char *function, uintptr_t offset) {
   (void) arg; (void) module; (void) addr; (void) offset;
   if (function != NULL) {
-    if (strcmp(function, "bt_crash") == 0) bt_saw_crash = 1;
-    if (strcmp(function, "bt_mid") == 0)   bt_saw_mid = 1;
+    if (strncmp(function, "bt_crash", strlen("bt_crash")) == 0) bt_saw_crash++;
+    if (strcmp(function, "bt_mid") == 0) bt_saw_mid++;
   }
 }
 
 static volatile int bt_sink;
-static NOINLINE void bt_crash(void) { CRASH(); }
-/* bt_sink++ after the call keeps bt_mid from tail-calling bt_crash, so it holds
- * a real frame the walk must recover. On arm64 that frame is reachable only via
- * LR (bt_crash faults as a leaf), so this also exercises the LR seeding. */
-static NOINLINE void bt_mid(void) { bt_crash(); bt_sink++; }
+static NOINLINE void bt_benign(void) { --bt_sink; }
+static NOINLINE void bt_crash(void) { bt_benign(); CRASH(); }
+static NOINLINE void bt_crash_leaf(void) { CRASH(); }
+static NOINLINE void bt_mid(int in_leaf) {
+#if defined (__aarch64__)
+  if (in_leaf) {
+    bt_crash_leaf(); /* crash in leaf; use LR to recover crash site. */
+  } else
+#else
+  (void)in_leaf;
+#endif
+  {
+    bt_crash(); /* aarch64: crash in non-leaf; LR -> spurious bt entry. */
+  }
+  bt_sink++; /* prevent tail-call to crash(), generating recoverable frame. */
+ }
 
 /* A caught crash exposes a backtrace naming the frames that led to it. */
-static NOINLINE int test_backtrace(void) {
+static NOINLINE int check_backtrace(int in_leaf) {
   volatile int caught = 0;
   volatile size_t size = 0;
   bt_saw_crash = 0;
   bt_saw_mid = 0;
   COFFEE_TRY() {
-    bt_mid();
+    bt_mid(in_leaf);
   } COFFEE_CATCH() {
     caught = 1;
     size = coffeecatch_get_backtrace_size();
@@ -424,19 +438,23 @@ static NOINLINE int test_backtrace(void) {
     coffeecatch_cancel_pending_alarm();
   } COFFEE_END();
   CHECK(caught);
-#if defined(__APPLE__)
-  /* The frame-pointer walk is what this feature adds: verify it reaches past
-   * the faulting leaf to its caller, and that both symbolize. */
-  CHECK(size > 0);
-  CHECK(bt_saw_crash);
+  CHECK(size > 2);
+#if defined(HAVE_BACKTRACE_NAMES)
+  CHECK(bt_saw_crash == 1);
   CHECK(bt_saw_mid);
-#elif defined(HAVE_BACKTRACE)
-  CHECK(size > 0);        /* unwind path present; symbol names not guaranteed */
-#else
-  CHECK(size == 0);       /* no collector compiled in */
 #endif
   return 0;
 }
+
+static NOINLINE int test_backtrace(void) {
+  return check_backtrace(0)
+#if defined(__aarch64__)
+    || check_backtrace(1)
+#endif
+  ;
+}
+
+#endif // HAVE_BACKTRACE
 
 /* --- fork harness -------------------------------------------------------- */
 
@@ -465,7 +483,9 @@ static const struct test tests[] = {
 #ifdef COFFEE_TESTING
   { "setup failure rolls back",     test_setup_failure_rolls_back, NULL },
 #endif
-  { "backtrace names the frames",   test_backtrace,   NULL },
+#ifdef HAVE_BACKTRACE
+  { "backtrace frames",             test_backtrace,   NULL },
+#endif
 };
 
 static int run_forked(const struct test *t) {


### PR DESCRIPTION
macOS left USE_UNWIND off because _Unwind_Backtrace() takes the dyld loader lock per frame and can self-deadlock on the crash path. Collect the backtrace by walking the frame-pointer chain from the trapping context instead: pure memory reads, so async-signal-safe, and it reuses the existing frame storage, get_backtrace API, symbolization, and the unwind_guarded nested-fault guard.

A new USE_FRAMEPOINTER sub-macro (set on __APPLE__, which also re-enables USE_UNWIND) routes coffeecatch_extract_backtrace() to the walker and keeps unwind.h and the _Unwind callback out of the Apple build. On arm64 the walk also seeds LR, de-duplicated against the first spilled copy, so the immediate caller of a leaf frame is not lost.

Limitation: frame-pointer unwinding misses frames built -fomit-frame-pointer and has no inline info. Apple arm64 mandates the frame pointer; on x86-64 it is reliable for our own code but not through every optimized system frame.

test_backtrace crashes through a non-tail call chain and, on Darwin, asserts the walk reaches the caller of the faulting leaf and both symbolize. The Linux/Android unwind path is unchanged and still only checks frames are present; the no-collector build checks the documented zero return.

Verified: macOS arm64 (native) and x86-64 (Rosetta); Linux gcc/clang default, -DUSE_UNWIND, and UBSan legs in docker.